### PR TITLE
Handle NFIT tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 cstr_core = { version = "0.2.3", default-features = false }
 bitflags = "1.2.1"
+uefi = "0.11.0"
 
 [target.'cfg(target_os = "none")'.dependencies]
 libacpica = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 cstr_core = { version = "0.2.3", default-features = false }
 bitflags = "1.2.1"
-uefi = "0.11.0"
 
 [target.'cfg(target_os = "none")'.dependencies]
 libacpica = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ x86 = "0.41"
 log = "0.4"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 cstr_core = { version = "0.2.3", default-features = false }
+bitflags = "1.2.1"
 
 [target.'cfg(target_os = "none")'.dependencies]
 libacpica = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 cstr_core = { version = "0.2.3", default-features = false }
 bitflags = "1.2.1"
+static_assertions = "1.1.0"
 
 [target.'cfg(target_os = "none")'.dependencies]
 libacpica = "0.0.8"

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -117,11 +117,10 @@ pub fn process_srat() -> (
     let mut mem_affinity = Vec::with_capacity(8);
 
     unsafe {
-        let srat_handle = CStr::from_bytes_with_nul_unchecked(b"SRAT\0");
         let mut table_header: *mut ACPI_TABLE_HEADER = ptr::null_mut();
 
         let ret = AcpiGetTable(
-            srat_handle.as_ptr() as *mut cstr_core::c_char,
+            ACPI_SIG_SRAT.as_ptr() as *mut cstr_core::c_char,
             1,
             &mut table_header,
         );
@@ -262,11 +261,10 @@ pub fn process_madt() -> (Vec<LocalApic>, Vec<LocalX2Apic>, Vec<IoApic>) {
     let mut io_apics = Vec::with_capacity(24);
 
     unsafe {
-        let madt_handle = CStr::from_bytes_with_nul_unchecked(b"APIC\0");
         let mut table_header: *mut ACPI_TABLE_HEADER = ptr::null_mut();
 
         let ret = AcpiGetTable(
-            madt_handle.as_ptr() as *mut cstr_core::c_char,
+            ACPI_SIG_MADT.as_ptr() as *mut cstr_core::c_char,
             1,
             &mut table_header,
         );
@@ -371,11 +369,10 @@ pub fn process_msct() -> (
     Vec<MaximumProximityDomainInfo>,
 ) {
     unsafe {
-        let msct_handle = CStr::from_bytes_with_nul_unchecked(b"MSCT\0");
         let mut table_header: *mut ACPI_TABLE_HEADER = ptr::null_mut();
 
         let ret = AcpiGetTable(
-            msct_handle.as_ptr() as *mut cstr_core::c_char,
+            ACPI_SIG_MSCT.as_ptr() as *mut cstr_core::c_char,
             1,
             &mut table_header,
         );
@@ -429,11 +426,10 @@ pub fn process_nfit() -> Vec<MemoryDescriptor> {
     let mut pmem_descriptors = Vec::with_capacity(8);
 
     unsafe {
-        let nfit_handle = CStr::from_bytes_with_nul_unchecked(b"NFIT\0");
         let mut table_header: *mut ACPI_TABLE_HEADER = ptr::null_mut();
 
         let ret = AcpiGetTable(
-            nfit_handle.as_ptr() as *mut cstr_core::c_char,
+            ACPI_SIG_NFIT.as_ptr() as *mut cstr_core::c_char,
             1,
             &mut table_header,
         );

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -2,6 +2,7 @@
 use bitflags::*;
 use libacpica::*;
 
+use core::fmt;
 use core::mem;
 use core::ptr;
 
@@ -484,6 +485,46 @@ pub fn process_nfit() {
         }
     }
 
+    struct Guid {
+        data1: u32,
+        data2: u16,
+        data3: u16,
+        index8: u8,
+        index9: u8,
+        index10: u8,
+        index11: u8,
+        index12: u8,
+        index13: u8,
+        index14: u8,
+        index15: u8,
+    }
+
+    impl fmt::Debug for Guid {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "{{ {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X}, {:#X} }}",
+                self.data1,
+                self.data2,
+                self.data3,
+                self.index8,
+                self.index9,
+                self.index10,
+                self.index11,
+                self.index12,
+                self.index13,
+                self.index14,
+                self.index15
+            )
+        }
+    }
+
+    fn from_slice_u8_to_Guid(slice: &[u8]) -> Guid {
+        let p: *const [u8; core::mem::size_of::<Guid>()] =
+            slice.as_ptr() as *const [u8; core::mem::size_of::<Guid>()];
+        unsafe { core::mem::transmute(*p) }
+    }
+
     fn fmt_nfit_spa_range_structure(entry: *const ACPI_NFIT_SYSTEM_ADDRESS) {
         unsafe {
             assert_eq!((*entry).Header.Type, 0);
@@ -501,7 +542,7 @@ pub fn process_nfit() {
                 (*entry).RangeIndex,
                 (*entry).Flags,
                 (*entry).ProximityDomain,
-                (*entry).RangeGuid,
+                from_slice_u8_to_Guid(&(*entry).RangeGuid),
                 (*entry).Address,
                 (*entry).Length,
                 MappingAttributes::from((*entry).MemoryMapping)

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -584,11 +584,32 @@ pub fn process_nfit() {
     }
 
     fn fmt_nfit_region_mapping_structure(entry: *const ACPI_NFIT_MEMORY_MAP) {
+        // To parse DeviceHandle
+        const ACPI_NFIT_DIMM_NUMBER: u32 = 0xf; /* DIMM number within the memory channel */
+        const ACPI_NFIT_MEMORY_CHANNEL: u32 = 0xf << 4; /* Memory channel number within the memory controller */
+        const ACPI_NFIT_MEM_CONTROLLER_ID: u32 = 0xf << 8; /* Memory controller ID within the socket */
+        const ACPI_NFIT_SOCKET_ID: u32 = 0xf << 12; /* Socket ID within the node controller, if any */
+        const ACPI_NFIT_NODE_CONTROLLER_ID: u32 = 0xfff << 16; /* Node controller ID, if any */
+
+        // To parse Flags
+        const ACPI_NFIT_MEM_SAVE_FAILED: u32 = 0x1; /* 00: Last SAVE to Memory Device failed */
+        const ACPI_NFIT_MEM_RESTORE_FAILED: u32 = 0x1 << 1; /* 01: Last RESTORE from Memory Device failed */
+        const ACPI_NFIT_MEM_FLUSH_FAILED: u32 = 0x1 << 2; /* 02: Platform flush failed */
+        const ACPI_NFIT_MEM_NOT_ARMED: u32 = 0x1 << 3; /* 03: Memory Device is not armed */
+        const ACPI_NFIT_MEM_HEALTH_OBSERVED: u32 = 0x1 << 4; /* 04: Memory Device observed SMART/health events */
+        const ACPI_NFIT_MEM_HEALTH_ENABLED: u32 = 0x1 << 5; /* 05: SMART/health events enabled */
+        const ACPI_NFIT_MEM_MAP_FAILED: u32 = 0x1 << 6; /* 06: Mapping to SPA failed */
+
         unsafe {
             assert_eq!((*entry).Header.Type, 1);
             debug!(
                 "ACPI_NFIT_TYPE_MEMORY_MAP - Type {}, Length {}
-                Device Handle: {},
+                NfitDeviceHandle: 0x{:x},
+                NfitDeviceHandle.DimmNumber: 0x{:x},
+                NfitDeviceHandle.MemChannel: 0x{:x},
+                NfitDeviceHandle.MemControllerId: 0x{:x},
+                NfitDeviceHandle.SocketId: 0x{:x},
+                NfitDeviceHandle.NodeControllerId: 0x{:x},
                 PhysicalId: {},
                 RegionId: {},
                 RangeIndex: {},
@@ -602,6 +623,11 @@ pub fn process_nfit() {
                 (*entry).Header.Type,
                 (*entry).Header.Length,
                 (*entry).DeviceHandle,
+                (*entry).DeviceHandle & ACPI_NFIT_DIMM_NUMBER,
+                (*entry).DeviceHandle & ACPI_NFIT_MEMORY_CHANNEL,
+                (*entry).DeviceHandle & ACPI_NFIT_MEM_CONTROLLER_ID,
+                (*entry).DeviceHandle & ACPI_NFIT_SOCKET_ID,
+                (*entry).DeviceHandle & ACPI_NFIT_NODE_CONTROLLER_ID,
                 (*entry).PhysicalId,
                 (*entry).RegionId,
                 (*entry).RangeIndex,

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -465,24 +465,24 @@ pub fn process_nfit() -> Vec<MemoryDescriptor> {
                 match entry_type {
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_SYSTEM_ADDRESS => {
                         let entry = iterator as *const ACPI_NFIT_SYSTEM_ADDRESS;
-                        let mem_desc = fmt_nfit_spa_range_structure(entry);
+                        let mem_desc = parse_nfit_spa_range_structure(entry);
                         pmem_descriptors.push(mem_desc);
                     }
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_MEMORY_MAP => {
                         let entry = iterator as *const ACPI_NFIT_MEMORY_MAP;
-                        fmt_nfit_region_mapping_structure(entry);
+                        parse_nfit_region_mapping_structure(entry);
                     }
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_INTERLEAVE => unreachable!(),
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_SMBIOS => unreachable!(),
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_CONTROL_REGION => {
                         let entry = iterator as *const ACPI_NFIT_CONTROL_REGION;
-                        fmt_nfit_control_region_structure(entry);
+                        parse_nfit_control_region_structure(entry);
                     }
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_DATA_REGION => unreachable!(),
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_FLUSH_ADDRESS => unreachable!(),
                     Enum_AcpiNfitType::ACPI_NFIT_TYPE_RESERVED => {
                         let entry = iterator as *const ACPI_NFIT_PLATFORM_CAPABILITIES;
-                        fmt_nfit_platform_capabilities_structure(entry);
+                        parse_nfit_platform_capabilities_structure(entry);
                     }
                     _ => unreachable!(),
                 }
@@ -566,7 +566,7 @@ fn from_slice_u8_to_Guid(slice: &[u8]) -> Guid {
     unsafe { core::mem::transmute(*p) }
 }
 
-fn fmt_nfit_spa_range_structure(entry: *const ACPI_NFIT_SYSTEM_ADDRESS) -> MemoryDescriptor {
+fn parse_nfit_spa_range_structure(entry: *const ACPI_NFIT_SYSTEM_ADDRESS) -> MemoryDescriptor {
     let mut mem_desc = MemoryDescriptor::default();
     unsafe {
         assert_eq!((*entry).Header.Type, 0);
@@ -604,7 +604,7 @@ fn fmt_nfit_spa_range_structure(entry: *const ACPI_NFIT_SYSTEM_ADDRESS) -> Memor
     }
 }
 
-fn fmt_nfit_region_mapping_structure(entry: *const ACPI_NFIT_MEMORY_MAP) {
+fn parse_nfit_region_mapping_structure(entry: *const ACPI_NFIT_MEMORY_MAP) {
     // To parse DeviceHandle
     const ACPI_NFIT_DIMM_NUMBER: u32 = 0xf; /* DIMM number within the memory channel */
     const ACPI_NFIT_MEMORY_CHANNEL: u32 = 0xf << 4; /* Memory channel number within the memory controller */
@@ -663,7 +663,7 @@ fn fmt_nfit_region_mapping_structure(entry: *const ACPI_NFIT_MEMORY_MAP) {
     }
 }
 
-fn fmt_nfit_control_region_structure(entry: *const ACPI_NFIT_CONTROL_REGION) {
+fn parse_nfit_control_region_structure(entry: *const ACPI_NFIT_CONTROL_REGION) {
     unsafe {
         assert_eq!((*entry).Header.Type, 4);
         debug!(
@@ -708,7 +708,7 @@ fn fmt_nfit_control_region_structure(entry: *const ACPI_NFIT_CONTROL_REGION) {
     }
 }
 
-fn fmt_nfit_platform_capabilities_structure(entry: *const ACPI_NFIT_PLATFORM_CAPABILITIES) {
+fn parse_nfit_platform_capabilities_structure(entry: *const ACPI_NFIT_PLATFORM_CAPABILITIES) {
     unsafe {
         const ACPI_NFIT_CACHE_FLUSH_ENABLED: u32 = 0x1;
         const ACPI_NFIT_CONTROLLER_FLUSH_ENABLED: u32 = 0x1 << 1;

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -535,10 +535,6 @@ impl From<&[u8; 16]> for Guid {
     }
 }
 
-// To parse DeviceHandle in ACPI_NFIT_MEMORY_MAP and ACPI_NFIT_FLUSH_ADDRESS subtables
-const ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK: u32 = 0xf;
-const ACPI_NFIT_DEVICE_HANDLE_12BIT_MASK: u32 = 0xfff;
-
 // NFIT subtable type = 0x0
 fn parse_nfit_spa_range_structure(entry: *const ACPI_NFIT_SYSTEM_ADDRESS) -> MemoryDescriptor {
     unsafe {
@@ -604,11 +600,11 @@ fn log_nfit_region_mapping_structure(entry: *const ACPI_NFIT_MEMORY_MAP) {
             (*entry).Header.Type,
             (*entry).Header.Length,
             (*entry).DeviceHandle,
-            (*entry).DeviceHandle & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 4) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 8) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 12) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 16) & ACPI_NFIT_DEVICE_HANDLE_12BIT_MASK,
+            (*entry).DeviceHandle & ACPI_NFIT_DIMM_NUMBER_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_CHANNEL_NUMBER_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_MEMORY_ID_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_SOCKET_ID_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_NODE_ID_OFFSET,
             (*entry).PhysicalId,
             (*entry).RegionId,
             (*entry).RangeIndex,
@@ -706,11 +702,11 @@ fn log_nfit_flush_hint_structure(entry: *const ACPI_NFIT_FLUSH_ADDRESS) {
             (*entry).Header.Type,
             (*entry).Header.Length,
             (*entry).DeviceHandle,
-            (*entry).DeviceHandle & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 4) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 8) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 12) & ACPI_NFIT_DEVICE_HANDLE_4BIT_MASK,
-            ((*entry).DeviceHandle >> 16) & ACPI_NFIT_DEVICE_HANDLE_12BIT_MASK,
+            (*entry).DeviceHandle & ACPI_NFIT_DIMM_NUMBER_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_CHANNEL_NUMBER_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_MEMORY_ID_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_SOCKET_ID_OFFSET,
+            (*entry).DeviceHandle & ACPI_NFIT_NODE_ID_OFFSET,
             (*entry).HintCount,
             (*entry).HintAddress[0],
         );
@@ -720,16 +716,12 @@ fn log_nfit_flush_hint_structure(entry: *const ACPI_NFIT_FLUSH_ADDRESS) {
 // NFIT subtable type = 0x7
 fn log_nfit_platform_capabilities_structure(entry: *const ACPI_NFIT_CAPABILITIES) {
     unsafe {
-        const ACPI_NFIT_CACHE_FLUSH_ENABLED: u32 = 0x1;
-        const ACPI_NFIT_CONTROLLER_FLUSH_ENABLED: u32 = 0x1 << 1;
-        const ACPI_NFIT_HARDWARE_MIRRORING_CAPABLE: u32 = 0x1 << 2;
-
         assert_eq!((*entry).Header.Type, 7);
         debug!(
             "Capability {{ eADR: {}, ADR: {}, Mirroring: {} }}",
-            (*entry).Capabilities & ACPI_NFIT_CACHE_FLUSH_ENABLED > 0,
-            (*entry).Capabilities & ACPI_NFIT_CONTROLLER_FLUSH_ENABLED > 0,
-            (*entry).Capabilities & ACPI_NFIT_HARDWARE_MIRRORING_CAPABLE > 0
+            (*entry).Capabilities & ACPI_NFIT_CAPABILITY_CACHE_FLUSH > 0,
+            (*entry).Capabilities & ACPI_NFIT_CAPABILITY_MEM_FLUSH > 0,
+            (*entry).Capabilities & ACPI_NFIT_CAPABILITY_MEM_MIRRORING > 0
         );
     }
 }

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -419,3 +419,20 @@ pub fn process_msct() -> (
         (msc, max_prox_domains)
     }
 }
+
+pub fn process_nfit() {
+    unsafe {
+        let nfit_handle = CStr::from_bytes_with_nul_unchecked(b"NFIT\0");
+        let mut table_header: *mut ACPI_TABLE_HEADER = ptr::null_mut();
+
+        let ret = AcpiGetTable(
+            nfit_handle.as_ptr() as *mut cstr_core::c_char,
+            1,
+            &mut table_header,
+        );
+        if ret != AE_OK {
+            info!("Failed - {}", ret);
+        }
+        info!("Passed - {}; Discoverd NVDIMMs {:?}", ret, table_header);
+    }
+}

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -504,7 +504,7 @@ pub fn process_nfit() -> Vec<MemoryDescriptor> {
     }
 }
 
-#[repr(C, align(8))]
+#[repr(C, packed)]
 struct Guid {
     data1: u32,
     data2: u16,
@@ -541,6 +541,10 @@ impl fmt::Debug for Guid {
 
 impl From<&[u8; 16]> for Guid {
     fn from(slice: &[u8; 16]) -> Guid {
+        // Check size and alignment for Guid
+        static_assertions::assert_eq_size!([u8; 16], Guid);
+        static_assertions::assert_eq_align!([u8; 16], Guid);
+
         let p: *const [u8; core::mem::size_of::<Guid>()] =
             slice.as_ptr() as *const [u8; core::mem::size_of::<Guid>()];
         unsafe { core::mem::transmute(*p) }

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -85,6 +85,10 @@ impl MemoryAffinity {
         self.base_address + self.length
     }
 
+    pub fn is_non_volatile(&self) -> bool {
+        self.non_volatile
+    }
+
     /// Splits a provided memory range into three sub-ranges (a, b, c).
     /// where
     ///  - a is the sub-range of input that comes before this MemoryAffinity.
@@ -131,10 +135,11 @@ impl fmt::Debug for MemoryAffinity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "MemoryAffinity {{ {:#x} -- {:#x}, node#{} }}",
+            "MemoryAffinity {{ {:#x} -- {:#x}, node#{}, Non-volatile: {} }}",
             self.start(),
             self.end(),
-            self.proximity_domain
+            self.proximity_domain,
+            self.is_non_volatile()
         )
     }
 }

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -1,5 +1,5 @@
 //! ACPI types which are parsed from tables (see also `acpi.rs`).
-
+use bitflags::*;
 use core::fmt;
 
 /// The I/O APIC structure declares which global system interrupts are uniquely
@@ -135,7 +135,7 @@ impl fmt::Debug for MemoryAffinity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "MemoryAffinity {{ {:#x} -- {:#x}, node#{}, {} }}",
+            "MemoryAffinity {{ {:#x} -- {:#x}, node#{} {} }}",
             self.start(),
             self.end(),
             self.proximity_domain,
@@ -245,4 +245,116 @@ pub struct MaximumProximityDomainInfo {
     /// Maximum Memory Capacity (size in bytes) of the Proximity Domains specified in the range.
     /// A value of 0 means that the proximity domains do not contain memory
     pub memory_capacity: u64,
+}
+
+/// The type of a memory range.
+///
+/// UEFI allows firmwares and operating systems to introduce new memory types
+/// in the 0x70000000..0xFFFFFFFF range. Therefore, we don't know the full set
+/// of memory types at compile time, and it is _not_ safe to model this C enum
+/// as a Rust enum.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(C)]
+pub enum MemoryType {
+    /// This enum variant is not used.
+    RESERVED = 0,
+    /// The code portions of a loaded UEFI application.
+    LOADER_CODE = 1,
+    /// The data portions of a loaded UEFI applications,
+    /// as well as any memory allocated by it.
+    LOADER_DATA = 2,
+    /// Code of the boot drivers.
+    ///
+    /// Can be reused after OS is loaded.
+    BOOT_SERVICES_CODE = 3,
+    /// Memory used to store boot drivers' data.
+    ///
+    /// Can be reused after OS is loaded.
+    BOOT_SERVICES_DATA = 4,
+    /// Runtime drivers' code.
+    RUNTIME_SERVICES_CODE = 5,
+    /// Runtime services' code.
+    RUNTIME_SERVICES_DATA = 6,
+    /// Free usable memory.
+    CONVENTIONAL = 7,
+    /// Memory in which errors have been detected.
+    UNUSABLE = 8,
+    /// Memory that holds ACPI tables.
+    /// Can be reclaimed after they are parsed.
+    ACPI_RECLAIM = 9,
+    /// Firmware-reserved addresses.
+    ACPI_NON_VOLATILE = 10,
+    /// A region used for memory-mapped I/O.
+    MMIO = 11,
+    /// Address space used for memory-mapped port I/O.
+    MMIO_PORT_SPACE = 12,
+    /// Address space which is part of the processor.
+    PAL_CODE = 13,
+    /// Memory region which is usable and is also non-volatile.
+    PERSISTENT_MEMORY = 14,
+}
+
+/// A structure describing a region of memory.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct MemoryDescriptor {
+    /// Type of memory occupying this range.
+    pub ty: MemoryType,
+    /// Skip 4 bytes as UEFI declares items in structs should be naturally aligned
+    pub padding: u32,
+    /// Starting physical address.
+    pub phys_start: u64,
+    /// Starting virtual address.
+    pub virt_start: u64,
+    /// Number of 4 KiB pages contained in this range.
+    pub page_count: u64,
+    /// The capability attributes of this memory range.
+    pub att: MemoryAttribute,
+}
+
+bitflags! {
+    /// Flags describing the capabilities of a memory range.
+    pub struct MemoryAttribute: u64 {
+        /// Supports marking as uncacheable.
+        const UNCACHEABLE = 0x1;
+        /// Supports write-combining.
+        const WRITE_COMBINE = 0x2;
+        /// Supports write-through.
+        const WRITE_THROUGH = 0x4;
+        /// Support write-back.
+        const WRITE_BACK = 0x8;
+        /// Supports marking as uncacheable, exported and
+        /// supports the "fetch and add" semaphore mechanism.
+        const UNCACHABLE_EXPORTED = 0x10;
+        /// Supports write-protection.
+        const WRITE_PROTECT = 0x1000;
+        /// Supports read-protection.
+        const READ_PROTECT = 0x2000;
+        /// Supports disabling code execution.
+        const EXECUTE_PROTECT = 0x4000;
+        /// Persistent memory.
+        const NON_VOLATILE = 0x8000;
+        /// This memory region is more reliable than other memory.
+        const MORE_RELIABLE = 0x10000;
+        /// This memory range can be set as read-only.
+        const READ_ONLY = 0x20000;
+        /// This memory range is for special purpose cases.
+        const SPECIAL_PURPOSE = 0x40000;
+        /// This memory must be mapped by the OS when a runtime service is called.
+        const RUNTIME = 0x8000_0000_0000_0000;
+    }
+}
+
+/// Convert u64 to MemoryAttribute.
+impl From<u64> for MemoryAttribute {
+    fn from(mode: u64) -> MemoryAttribute {
+        MemoryAttribute::from_bits_truncate(mode)
+    }
+}
+
+/// Convert MemoryAttribute to u64.
+impl From<MemoryAttribute> for u64 {
+    fn from(mode: MemoryAttribute) -> u64 {
+        mode.bits()
+    }
 }

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -1,4 +1,5 @@
 //! ACPI types which are parsed from tables (see also `acpi.rs`).
+#[allow(non_camel_case_types)]
 use bitflags::*;
 use core::fmt;
 

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -135,11 +135,11 @@ impl fmt::Debug for MemoryAffinity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "MemoryAffinity {{ {:#x} -- {:#x}, node#{}, Non-volatile: {} }}",
+            "MemoryAffinity {{ {:#x} -- {:#x}, node#{}, {} }}",
             self.start(),
             self.end(),
             self.proximity_domain,
-            self.is_non_volatile()
+            if self.is_non_volatile() { "nvm" } else { "" },
         )
     }
 }

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -1,5 +1,5 @@
 //! ACPI types which are parsed from tables (see also `acpi.rs`).
-#[allow(non_camel_case_types)]
+#![allow(non_camel_case_types)]
 use bitflags::*;
 use core::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,13 @@ use alloc::vec::Vec;
 #[cfg(target_os = "none")]
 use core::convert::TryInto;
 use core::fmt;
+use uefi::table::boot::MemoryDescriptor;
 
 use lazy_static::lazy_static;
 use x86::apic::ApicId;
 
 #[cfg(target_os = "none")]
-pub use acpi::process_nfit;
-#[cfg(target_os = "none")]
-use acpi::{process_madt, process_msct, process_srat};
+use acpi::{process_madt, process_msct, process_nfit, process_srat};
 use acpi_types::{
     IoApic, LocalApic, LocalX2Apic, MaximumProximityDomainInfo, MaximumSystemCharacteristics,
     MemoryAffinity,
@@ -354,6 +353,7 @@ lazy_static! {
         let (mut local_apics, mut local_x2apics, ioapics) = process_madt();
         let (mut core_affinity, mut x2apic_affinity, memory_affinity) = process_srat();
         let (max_proximity_info, prox_domain_info) = process_msct();
+        let pmem_descriptors = process_nfit();
 
         local_apics.sort_unstable_by(|a, b| a.apic_id.cmp(&b.apic_id));
         local_x2apics.sort_unstable_by(|a, b| a.apic_id.cmp(&b.apic_id));
@@ -443,6 +443,7 @@ lazy_static! {
             nodes,
             ioapics,
             memory_affinity,
+            pmem_descriptors,
             max_proximity_info,
             prox_domain_info
         )
@@ -461,6 +462,7 @@ lazy_static! {
         let memory_affinity = Vec::new();
         let max_proximity_info = MaximumSystemCharacteristics::default();
         let prox_domain_info = Vec::new();
+        let pmem_descriptors = Vec::new();
 
         // Make Thread objects out of APIC MADT entries:
         let mut threads: Vec<Thread> = Vec::new();
@@ -510,6 +512,7 @@ lazy_static! {
             nodes,
             ioapics,
             memory_affinity,
+            pmem_descriptors,
             max_proximity_info,
             prox_domain_info
         )
@@ -525,6 +528,7 @@ pub struct MachineInfo {
     packages: Vec<Package>,
     nodes: Vec<Node>,
     memory_affinity: Vec<MemoryAffinity>,
+    pmem_descriptors: Vec<MemoryDescriptor>,
     io_apics: Vec<IoApic>,
     max_proximity_info: MaximumSystemCharacteristics,
     proximity_domains: Vec<MaximumProximityDomainInfo>,
@@ -539,6 +543,7 @@ impl MachineInfo {
         nodes: Vec<Node>,
         io_apics: Vec<IoApic>,
         memory_affinity: Vec<MemoryAffinity>,
+        pmem_descriptors: Vec<MemoryDescriptor>,
         max_proximity_info: MaximumSystemCharacteristics,
         proximity_domains: Vec<MaximumProximityDomainInfo>,
     ) -> MachineInfo {
@@ -548,6 +553,7 @@ impl MachineInfo {
             packages,
             nodes,
             memory_affinity,
+            pmem_descriptors,
             io_apics,
             max_proximity_info,
             proximity_domains,
@@ -648,6 +654,10 @@ impl MachineInfo {
     /// Return an iterator over all I/O APICs in the system.
     pub fn io_apics(&'static self) -> impl Iterator<Item = &IoApic> {
         self.io_apics.iter()
+    }
+
+    pub fn persistent_memory(&'static self) -> impl Iterator<Item = &'static MemoryDescriptor> {
+        MACHINE_TOPOLOGY.pmem_descriptors.iter()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use core::fmt;
 use lazy_static::lazy_static;
 use x86::apic::ApicId;
 
+#[cfg(target_os = "none")]
 pub use acpi::process_nfit;
 #[cfg(target_os = "none")]
 use acpi::{process_madt, process_msct, process_srat};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use core::fmt;
 use lazy_static::lazy_static;
 use x86::apic::ApicId;
 
+pub use acpi::process_nfit;
 #[cfg(target_os = "none")]
 use acpi::{process_madt, process_msct, process_srat};
 use acpi_types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,16 +24,16 @@ use alloc::vec::Vec;
 #[cfg(target_os = "none")]
 use core::convert::TryInto;
 use core::fmt;
-use uefi::table::boot::MemoryDescriptor;
 
 use lazy_static::lazy_static;
 use x86::apic::ApicId;
 
 #[cfg(target_os = "none")]
 use acpi::{process_madt, process_msct, process_nfit, process_srat};
+pub use acpi_types::MemoryType;
 use acpi_types::{
     IoApic, LocalApic, LocalX2Apic, MaximumProximityDomainInfo, MaximumSystemCharacteristics,
-    MemoryAffinity,
+    MemoryAffinity, MemoryDescriptor,
 };
 
 /// A system global ID for a CPU.


### PR DESCRIPTION
Even though the code handles all the required subtables, it doesn't store or uses all that information for now. It only stores address ranges and affinity information to be used by NRKernel.