### PR TITLE
Check if a memory-affinity region is for hot plugged memory.

### DIFF
--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -93,7 +93,7 @@ impl MemoryAffinity {
 
     /// Check if the region is reserved for hotplugged memory.
     pub fn is_hotplug_region(&self) -> bool {
-        self.enabled & self.hotplug_capable
+        self.enabled && self.hotplug_capable
     }
 
     /// Splits a provided memory range into three sub-ranges (a, b, c).

--- a/src/acpi_types.rs
+++ b/src/acpi_types.rs
@@ -86,8 +86,14 @@ impl MemoryAffinity {
         self.base_address + self.length
     }
 
+    /// Check if the region is nvm or not.
     pub fn is_non_volatile(&self) -> bool {
         self.non_volatile
+    }
+
+    /// Check if the region is reserved for hotplugged memory.
+    pub fn is_hotplug_region(&self) -> bool {
+        self.enabled & self.hotplug_capable
     }
 
     /// Splits a provided memory range into three sub-ranges (a, b, c).


### PR DESCRIPTION
Qemu uses the `slots` option to add vNVDIMMs that modifies the SRAT functionality. Now, it adds a memory region for the hotplugged devices. However, this affects NRK tests and internal functionality that relies on memory affinity tables to provide regions for currently plugged DIMMs.